### PR TITLE
Add mariadb support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,31 @@ matrix:
   fast-finish: true
   include:
     - env:
-      - DB_VERSION: 5.5
+      - DB_VERSION: mysql:5.5
     - env:
-      - DB_VERSION: 5.6
+      - DB_VERSION: mysql:5.6
     - env:
-      - DB_VERSION: 5.7
+      - DB_VERSION: mysql:5.7
     - env:
-      - DB_VERSION: 8
+      - DB_VERSION: mysql:8
     - env:
-      - DB_VERSION: latest
+      - DB_VERSION: mysql:latest
+    - env:
+      - DB_VERSION: mariadb:5.5
+    - env:
+      - DB_VERSION: mariadb:10.2
+    - env:
+      - DB_VERSION: mariadb:10.3
+    - env:
+      - DB_VERSION: mariadb:10.4
+    - env:
+      - DB_VERSION: mariadb:latest
 
 before_install:
   - curl -fsSL https://deno.land/x/install/install.sh | sh
   - export PATH="/home/travis/.deno/bin:$PATH"
   
 script:
-  - docker run -d -p $DB_PORT:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:$DB_VERSION
+  - docker run -d -p $DB_PORT:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=true $DB_VERSION
   - sleep 10
   - deno run --allow-all ./test.ts

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 ![GitHub release](https://img.shields.io/github/release/manyuanrong/deno_mysql.svg)
 ![(Deno)](https://img.shields.io/badge/deno-0.24.0-green.svg)
 
-MySQL database driver for Deno.
+MySQL and MariaDB (5.5 and 10.2+) database driver for Deno.
+
+MariaDB 10.0 and 10.1 are not supported at the moment
 
 On this basis, there is also an ORM library: [Deno Simple Orm](https://github.com/manyuanrong/dso)
 
@@ -24,6 +26,8 @@ On this basis, there is also an ORM library: [Deno Simple Orm](https://github.co
 - [x] Connection pool
 - [x] Transaction
 - [x] Test case
+- [ ] Support MariaDB 10.0
+- [ ] Support MariaDB 10.1
 
 ## API
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -162,8 +162,8 @@ export class Connection {
     }
 
     const rows = [];
-    if (this.serverVersion < "5.7.0") {
-      // EOF(less than 5.7)
+    if (this.serverVersion < "5.7.0" && this.serverVersion.substr(-7) !== 'MariaDB') {
+      // EOF(less than 5.7 excluding MariaDB) 
       receive = await this.nextPacket();
     }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -115,6 +115,27 @@ export class Connection {
     }
   }
 
+  /**
+   * Check if database server version is less than 5.7.0
+   *
+   * MySQL version is "x.y.z"
+   *   eg "5.5.62"
+   *
+   * MariaDB version is "5.5.5-x.y.z-MariaDB[-build-infos]" for versions after 5 (10.0 etc)
+   *   eg "5.5.5-10.4.10-MariaDB-1:10.4.10+maria~bionic"
+   * and "x.y.z-MariaDB-[build-infos]" for 5.x versions
+   *   eg "5.5.64-MariaDB-1~trusty"
+   */
+  private lessThan57(): Boolean {
+    const version = this.serverVersion;
+    if (!version.includes("MariaDB")) return version < "5.7.0";
+    const segments = version.split("-");
+    // MariaDB v5.x
+    if (segments[1] === "MariaDB") return segments[0] < "5.7.0";
+    // MariaDB v10+
+    return false;
+  }
+
   /** Close database connection */
   close(): void {
     log.info("close connection");
@@ -162,8 +183,8 @@ export class Connection {
     }
 
     const rows = [];
-    if (this.serverVersion < "5.7.0" && this.serverVersion.substr(-7) !== 'MariaDB') {
-      // EOF(less than 5.7 excluding MariaDB) 
+    if (this.lessThan57()) {
+      // EOF(less than 5.7)
       receive = await this.nextPacket();
     }
 


### PR DESCRIPTION
Add support for MariaDB version 5.5 and 10.2 to 10.4.

The version returned by MariaDB server has a variable form and was badly interpreted. 

For some reason, currently the 10.0 and 10.1 versions return some strange values that break tests and are therefore unsupported.

Tests has been added to travis with each version plus the `latest` like previously (small update to `.travis.yml` to include `mysql|mariadb` in env)