### PR TITLE
feat: update to std@v0.50.0

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { decode, encode } from "https://deno.land/std@v0.42.0/encoding/utf8.ts";
+export { decode, encode } from "https://deno.land/std@v0.50.0/encoding/utf8.ts";
 export { format as byteFormat } from "https://deno.land/x/bytes_formater@1.1.0/mod.ts";
 export { replaceParams } from "https://deno.land/x/sql_builder@1.3.5/util.ts";
 export { Hash } from "https://deno.land/x/checksum@1.2.0/mod.ts";
@@ -8,9 +8,9 @@ export {
   deferred,
   Deferred,
   delay,
-} from "https://deno.land/std@v0.42.0/util/async.ts";
+} from "https://deno.land/std@v0.50.0/async/mod.ts";
 
 export {
   assertEquals,
   assertThrowsAsync,
-} from "https://deno.land/std@v0.42.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.50.0/testing/asserts.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export { decode, encode } from "https://deno.land/std@v0.50.0/encoding/utf8.ts";
-export { format as byteFormat } from "https://deno.land/x/bytes_formater@1.1.0/mod.ts";
+export { format as byteFormat } from "https://deno.land/x/bytes_formater@1.2.0/mod.ts";
 export { replaceParams } from "https://deno.land/x/sql_builder@1.3.5/util.ts";
 export { Hash } from "https://deno.land/x/checksum@1.2.0/mod.ts";
 export { sha256 } from "https://denopkg.com/chiefbiiko/sha256@v1.0.2/mod.ts";


### PR DESCRIPTION
This requires last [PR](https://github.com/manyuanrong/bytes_formater/pull/1) for bytes_formater to be published, which also updates the deps to v0.50.0.