### PR TITLE
Fix CI failure introduced by #63

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -4,10 +4,6 @@ export {
   delay,
 } from "https://deno.land/std@0.53.0/async/mod.ts";
 export { decode, encode } from "https://deno.land/std@0.53.0/encoding/utf8.ts";
-export {
-  assertEquals,
-  assertThrowsAsync,
-} from "https://deno.land/std@0.53.0/testing/asserts.ts";
 export { format as byteFormat } from "https://deno.land/x/bytes_formater@1.2.0/mod.ts";
 export { Hash } from "https://deno.land/x/checksum@1.4.0/mod.ts";
 export { sha256 } from "https://deno.land/x/sha256@v1.0.2/mod.ts";

--- a/test.deps.ts
+++ b/test.deps.ts
@@ -1,0 +1,5 @@
+export {
+  assertEquals,
+  assertThrowsAsync,
+} from "https://deno.land/std@0.53.0/testing/asserts.ts";
+export * as semver from "https://deno.land/x/semver@v1.0.0/mod.ts";


### PR DESCRIPTION
- Added semver check for the `testQueryDatetime` case
  - MySQL < v5.6.0 does not support `datetime` with length.
- Separated `test.deps.ts` from `deps.ts`