### PR TITLE
Bump dependencies version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Deno
         uses: denolib/setup-deno@master
         with:
-          deno-version: 1.0.2
+          deno-version: 1.2.2
       - name: check fmt
         run: deno fmt --check
       - name: test ts

--- a/deps.ts
+++ b/deps.ts
@@ -4,7 +4,7 @@ export {
   delay,
 } from "https://deno.land/std@0.63.0/async/mod.ts";
 export { decode, encode } from "https://deno.land/std@0.63.0/encoding/utf8.ts";
-export { format as byteFormat } from "https://deno.land/x/bytes_formater@1.2.0/mod.ts";
+export { format as byteFormat } from "https://deno.land/x/bytes_formater@v1.3.0/mod.ts";
 export { Hash } from "https://deno.land/x/checksum@1.4.0/mod.ts";
 export { sha256 } from "https://deno.land/x/sha256@v1.0.2/mod.ts";
 export { replaceParams } from "https://deno.land/x/sql_builder@v1.6.0/util.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -2,10 +2,10 @@ export {
   deferred,
   Deferred,
   delay,
-} from "https://deno.land/std@0.53.0/async/mod.ts";
-export { decode, encode } from "https://deno.land/std@0.53.0/encoding/utf8.ts";
+} from "https://deno.land/std@0.63.0/async/mod.ts";
+export { decode, encode } from "https://deno.land/std@0.63.0/encoding/utf8.ts";
 export { format as byteFormat } from "https://deno.land/x/bytes_formater@1.2.0/mod.ts";
 export { Hash } from "https://deno.land/x/checksum@1.4.0/mod.ts";
 export { sha256 } from "https://deno.land/x/sha256@v1.0.2/mod.ts";
 export { replaceParams } from "https://deno.land/x/sql_builder@v1.6.0/util.ts";
-export * as log from "https://deno.land/x/std@0.53.0/log/mod.ts";
+export * as log from "https://deno.land/x/std@0.63.0/log/mod.ts";

--- a/test.deps.ts
+++ b/test.deps.ts
@@ -1,5 +1,5 @@
 export {
   assertEquals,
   assertThrowsAsync,
-} from "https://deno.land/std@0.53.0/testing/asserts.ts";
+} from "https://deno.land/std@0.63.0/testing/asserts.ts";
 export * as semver from "https://deno.land/x/semver@v1.0.0/mod.ts";


### PR DESCRIPTION
- Upgrade std to `0.63.0`
- Upgrade bytes_formater to `v1.3.0`
- All green ✅