### PR TITLE
Enable Visual Studio code's deno extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 package-lock.json
 tsconfig.json
-.vscode
 node_modules
 mysql.log
 docs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enable": true
+}


### PR DESCRIPTION
It requires the .vscode/settings.json file to have deno.enable true.

It's easier if the file is committed, so new developers immediately have
the plugin enabled.