### PR TITLE
Document running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
         run: deno fmt --check
       - name: test ts
         run: |
-          docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=true ${{ matrix.DB_VERSION }}
+          docker container run --rm -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=true ${{ matrix.DB_VERSION }}
           ./.github/workflows/wait-for-mysql.sh
-          deno test --allow-all ./test.ts
+          deno test --allow-env --allow-net=127.0.0.1:3306 ./test.ts

--- a/README.md
+++ b/README.md
@@ -135,3 +135,15 @@ console.log(users.length);
 ```ts
 await client.close();
 ```
+
+## Test
+
+The tests require a database to run against.
+
+```bash
+docker container run --rm -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=true docker.io/mariadb:latest
+deno test --allow-env --allow-net=127.0.0.1:3306 ./test.ts
+```
+
+Use different docker images to test against different versions of MySQL and MariaDB.
+Please see [ci.yml](./.github/workflows/ci.yml) for examples.


### PR DESCRIPTION
One of the first things I do when checking out a project is to run the
tests. Making it clear how to run them is important to me.

I've changed the ci.yml as it is an example of how to run the tests.

I've set the tests to run with less permissions, because it helps give
confidence that they are safe.

I've switched the docker command to use the container subcommand,
because I think it reads better, and it is the way the docker
documentation recommends.

https://www.docker.com/blog/whats-new-in-docker-1-13/#h.yuluxi90h1om